### PR TITLE
이메일 인증 코드 형식 변경 및 변경에 따른 입력값 제한 기능 추가

### DIFF
--- a/backend/src/main/java/com/sepay/backend/mail/service/MailServiceImpl.java
+++ b/backend/src/main/java/com/sepay/backend/mail/service/MailServiceImpl.java
@@ -34,20 +34,8 @@ public class MailServiceImpl implements MailService {
     public String createVerificationCode() {
         StringBuilder code = new StringBuilder();
 
-        for (int i = 0; i < 10; i++) {
-            int random = (int) (Math.random() * 3); // 0: 숫자, 1,2: 알파벳
-
-            if (random == 0) {
-                code.append((int) (Math.random() * 10));
-            } else {
-                char alphabet = (char) ((int) (Math.random() * 26) + 65);
-                int upperOrLower = (int) (Math.random() * 2); // 0: 대문자, 1: 소문자
-                if (upperOrLower == 0) {
-                    code.append(alphabet);
-                } else {
-                    code.append(Character.toLowerCase(alphabet));
-                }
-            }
+        for (int i = 0; i < 6; i++) {
+            code.append((int) (Math.random() * 10));
         }
         return code.toString();
     }

--- a/frontend/src/locales/csv/locales.csv
+++ b/frontend/src/locales/csv/locales.csv
@@ -397,7 +397,7 @@ signUp--verify,인증,Verify,Memeriksa,Xác minh
 signUp--pw,비밀번호,Your password,Kata sandi Anda,Mật khẩu của bạn
 signUp--pwPlaceholder,비밀번호,Password,Kata sandi,Mật khẩu
 signUp--confirmPw,비밀번호 확인,Confirm your password,Konfirmasi kata sandi Anda,Xác nhận mật khẩu của bạn
-signUp--confirmPwPlaceholder,비밀번호 확인,,Konfirmasikan kata sandi,Xác nhận mật khẩu
+signUp--confirmPwPlaceholder,비밀번호 확인,Confirm password,Konfirmasikan kata sandi,Xác nhận mật khẩu
 signUp--country,거주 국가,Country of residence,Negara tempat tinggal,Quốc gia cư trú
 signUp--countryCodeLabel,국가,Country,Negara,Quốc gia
 signUp--countryUS,미국,United States,Amerika Serikat,Hoa Kỳ

--- a/frontend/src/views/signUp/RegisterDetails.vue
+++ b/frontend/src/views/signUp/RegisterDetails.vue
@@ -134,6 +134,11 @@ const sendEmailCode = async () => {
 // 이메일 인증 코드 입력 필드 상태
 const emailCode = ref("");
 
+// 인증 코드 입력 숫자만 허용(최대 6자리)
+const handleEmailCode = (event) => {
+  emailCode.value = event.target.value.replace(/\D/g, "").slice(0, 6);
+};
+
 // 인증 코드 검증 상태
 const isVerified = ref(false);
 
@@ -389,6 +394,7 @@ const handleSubmit = async () => {
                         class="col-xl col-md col-sm"
                         :placeholder="$t('signUp--emailCodePlaceholder')"
                         v-model="emailCode"
+                        @input="handleEmailCode"
                         :class="{ 'is-invalid': emailCodeError }"
                         :success="!emailCodeError && isVerified"
                         :error="

--- a/frontend/src/views/signUp/RegisterLegal.vue
+++ b/frontend/src/views/signUp/RegisterLegal.vue
@@ -57,7 +57,7 @@ const handleNext = () => {
 };
 
 // 이용 약관과 개인정보 보호정책(다국어 지원)
-const termsOfUse = t("signUp--termsOfUse");
+const termsOfService = t("signUp--termsOfService");
 const privacyPolicy = t("signUp--privacyPolicy");
 </script>
 <template>
@@ -110,7 +110,7 @@ const privacyPolicy = t("signUp--privacyPolicy");
                       <div
                         class="form-control bg-white"
                         style="height: 72px; overflow-y: auto"
-                        v-html="termsOfUse"
+                        v-html="termsOfService"
                       ></div>
                     </div>
                     <!-- 개인정보 보호정책 동의 -->


### PR DESCRIPTION
## 🛠 구현 사항
- 이메일 인증 코드 형식 변경에 따라 인증 코드 입력 input 숫자만 받고 최대 6자리만 입력가능하도록 제한

## 📚 변경 사항
- 백엔드 이메일 인증 코드 형식 변경: 문자열+숫자 랜덤 10자리 -> 숫자로만 6자리 

## 그 외
- 다국어 처리 일부 빼먹은 부분 수정